### PR TITLE
Kernel: add new class named `Kernel`

### DIFF
--- a/Kernel/Kernel.st
+++ b/Kernel/Kernel.st
@@ -1,0 +1,23 @@
+"
+    Copyright (c) 2020 LabWare.
+    See (MIT) license in root directory.
+"
+
+Class {
+	#name : #Kernel,
+	#superclass : #Module,
+	#instVars : [
+		'entryPointCode',
+                'entryPointReceiver',
+		'nilObj',
+		'trueObj',
+		'falseObj',
+		'dlopenPtr',
+		'dlsymPtr'
+	],
+	#category : #Kernel
+}
+
+Kernel >> entry: argc argv: argv [
+	self halt.
+]


### PR DESCRIPTION
Normally a segment (module) is described by an instance of `Module`. However, for
launcher (or native VM) to load and transfer execution to smalltalk code. it has to
know locations to certain objects such as `nil`, `true`, `false` (and few others,
more may come in future, especially to support native VM).

To solve this, the kernel segment is described by a `Module` subclass: `Kernel` which
has a bunch of extra instance variables holding on these special objects (pretty
much like special objects array in OSVM).