### PR TITLE
Kernel: reorder instvars in `CompiledMethod` and `CompiledBlock`

### DIFF
--- a/Kernel/CompiledBlock.st
+++ b/Kernel/CompiledBlock.st
@@ -1,5 +1,6 @@
 "
     Copyright (c) 2020 Aucerna. 
+    Copyright (c) 2020 LabWare. 
     See (MIT) license in root directory.
 "
 
@@ -8,9 +9,9 @@ Class {
 	#superclass : #Object,
 	#type : #variable,
 	#instVars : [
-		'method',
 		'format',
-		'nativeCode'
+		'nativeCode',
+		'method'
 	],
 	#classVars : [
 		'Flags'

--- a/Kernel/CompiledMethod.st
+++ b/Kernel/CompiledMethod.st
@@ -1,5 +1,6 @@
 "
     Copyright (c) 2020 Aucerna. 
+    Copyright (c) 2020 LabWare.
     See (MIT) license in root directory.
 "
 
@@ -8,12 +9,12 @@ Class {
 	#superclass : #Array,
 	#type : #variable,
 	#instVars : [
-		'astcodes',
+		'format',
 		'nativeCode',
+		'astcodes',
 		'class',
 		'selector',
-		'source',
-		'format'
+		'source'
 	],
 	#classVars : [
 		'Flags'


### PR DESCRIPTION
so positions of `format` and `nativeCode` match in both. This simplifies
native code. I'd perhaps be useful to factor out a common superclass
but that's not done in this commit.