### PR TITLE
Added required method categories

### DIFF
--- a/Kernel/Class.st
+++ b/Kernel/Class.st
@@ -15,6 +15,7 @@ Class {
 	#category : #Kernel
 }
 
+{ #category : #'instance creation' }
 Class class >> newSubclassOf: aClass [
 	| meta |
 	meta := Metaclass new beSubclassOf: aClass class.

--- a/Kernel/KernelModule.st
+++ b/Kernel/KernelModule.st
@@ -65,6 +65,7 @@ KernelModule >> addModuleLoader: aModuleLoader [
 	moduleLoaders add: aModuleLoader
 ]
 
+{ #category : #entry }
 KernelModule >> entry: argc argv: argv [
 	<callback: long (long, pointer)>
 	"^Smalltalk startSession"
@@ -112,6 +113,7 @@ KernelModule >> prepareForExecution: aCompiledMethod [
 	self errorVMSpecific
 ]
 
+{ #category : #testing }
 KernelModule >> foo [
 	| result |
 	"self _halt."

--- a/Kernel/WideSymbol.st
+++ b/Kernel/WideSymbol.st
@@ -90,6 +90,7 @@ WideSymbol >> atValid: index [
 	^Character value: cp
 ]
 
+{ #category : #accessing }
 WideSymbol >> basicSize [
 	^self _size
 ]


### PR DESCRIPTION
I have a simple Tonel reader which requires a method category before each method.
There are only a few cases where these are lacking.
